### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/documents/pages/index.html
+++ b/documents/pages/index.html
@@ -111,7 +111,7 @@
            alt="latest DOI">
     </a>
     <!--
-    <a href="http://dx.doi.org/10.5281/zenodo.46714">
+    <a href="https://doi.org/10.5281/zenodo.46714">
       <img src="https://zenodo.org/badge/doi/10.5281/zenodo.46714.svg" 
            alt="10.5281/zenodo.46714">
     </a>

--- a/documents/publications/LDOW2016-paper/Annalist-refs.bib
+++ b/documents/publications/LDOW2016-paper/Annalist-refs.bib
@@ -312,7 +312,7 @@
     doi         = {10.1017/S0956796807006326},
 } 
     issn        = {0956-7968},
-    url         = {http://dx.doi.org/10.1017/S0956796807006326}
+    url         = {https://doi.org/10.1017/S0956796807006326}
 
 @article{miles2010,
     title       = {{OpenFlyData}: An exemplar data web integrating gene expression data on the fruit fly \emph{Drosophila Melanogaster}},
@@ -323,7 +323,7 @@
     number      = {5},
     pages       = {752 - 761},
     year        = {2010},
-    doi         = {http://dx.doi.org/10.1016/j.jbi.2010.04.00},
+    doi         = {https://doi.org/10.1016/j.jbi.2010.04.00},
 }
     issn        = {1532-0464},
     keywords    = {Chado},
@@ -352,7 +352,7 @@
     doi         = {10.1007/11926078_12},
 } 
     isbn        = {3-540-49029-9, 978-3-540-49029-6},
-    url         = {http://dx.doi.org/10.1007/11926078_12}
+    url         = {https://doi.org/10.1007/11926078_12}
 
 @misc{protege,
     title       = {Prot\'{e}g\'{e} ontology editor},
@@ -377,7 +377,7 @@
     publisher   = {European Association of Software Science and Technology},
     doi         = {10.14279/tuj.eceasst.57.879}
 }
-    url         = {http://dx.doi.org/10.14279/tuj.eceasst.57.879}
+    url         = {https://doi.org/10.14279/tuj.eceasst.57.879}
 
 @misc{rauschmayer2008,
     title       = {Hyena {RDF} editor},
@@ -661,7 +661,7 @@
     year        = {2012},
     month       = {10},
     day         = {8-12},
-    url         = {http://dx.doi.org/10.1109/eScience.2012.6404412},
+    url         = {https://doi.org/10.1109/eScience.2012.6404412},
 
 @inproceedings{zhao2013,
     Title       = {A Check\-list-Based Approach for Quality Assessment of Scientific Information},
@@ -704,7 +704,7 @@
 }
     isbn        = {978-0-12-164730-8},
     editor      = {Celis, Julio E. },
-    doi         = {http://dx.doi.org/10.1016/B978-012164730-8/50149-0},
+    doi         = {https://doi.org/10.1016/B978-012164730-8/50149-0},
     url         = {http://www.sciencedirect.com/science/article/pii/B9780121647308501490}
 
 @incollection{zhao2008,
@@ -720,7 +720,7 @@
     doi         ={10.1007/978-3-540-68234-9_14},
 }
     isbn        ={978-3-540-68233-2},
-    url         ={http://dx.doi.org/10.1007/978-3-540-68234-9_14}
+    url         ={https://doi.org/10.1007/978-3-540-68234-9_14}
 
 @article{zhao2010,
     title       = {{FlyTED}: the \emph{Dros\-ophila} Testis Gene Expression Database},
@@ -766,7 +766,7 @@
     year        = {2015},
     doi         = {10.1093/nar/gku1099},
 }   
-    url         = {http://dx.doi.org/10.1093/nar/gku1099},
+    url         = {https://doi.org/10.1093/nar/gku1099},
 
 
 
@@ -895,7 +895,7 @@
     Number = {8},
     Pages = {889--896},
     Publisher = {Nature Publishing Group},
-    Url = {http://dx.doi.org/10.1038/nbt.1411},
+    Url = {https://doi.org/10.1038/nbt.1411},
     }
     Isbn = {1087-0156},
 
@@ -1136,7 +1136,7 @@ keywords = "Publishing"
   year      = {2003},
   pages     = {197-224},
 }
-  ee        = {http://dx.doi.org/10.1142/S0218843003000711},
+  ee        = {https://doi.org/10.1142/S0218843003000711},
   bibsource = {DBLP, http://dblp.uni-trier.de}
 
 @inproceedings{DBLP:conf/icws/TranT07,
@@ -1182,7 +1182,7 @@ month = {May}
   year      = {2011},
   pages     = {743-756},
 }
-  ee        = {http://dx.doi.org/10.1016/j.future.2010.07.005},
+  ee        = {https://doi.org/10.1016/j.future.2010.07.005},
   bibsource = {DBLP, http://dblp.uni-trier.de}
 
 @inproceedings{opmw,
@@ -1206,7 +1206,7 @@ month = {May}
   Number = {7386},
   Pages = {485--488},
   Publisher = {Nature Publishing Group, a division of Macmillan Publishers Limited. All Rights Reserved.},
-  Url = {http://dx.doi.org/10.1038/nature10836},
+  Url = {https://doi.org/10.1038/nature10836},
   Volume = {482},
   Year = {2012},
   }

--- a/documents/publications/LDOW2016-paper/sig-alternate-05-2015.cls
+++ b/documents/publications/LDOW2016-paper/sig-alternate-05-2015.cls
@@ -179,7 +179,7 @@
 
 
 \def\doi#1{\def\@doi{#1}}
-\doi{http://dx.doi.org/10.1145/0000000.0000000}
+\doi{https://doi.org/10.1145/0000000.0000000}
 
 \oddsidemargin 4.5pc
 \evensidemargin 4.5pc


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8) and Zenodo started using it for its badges as well. Accordingly, this PR updates all DOI links.

Cheers!